### PR TITLE
Add x# amount text for instructions and optionally centered smithing instructions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,20 +1,28 @@
+# Simple workflow for deploying static content to GitHub Pages
 name: Deploy static content to Pages
 
 on:
+  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
+  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -23,15 +31,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Pages
         uses: actions/configure-pages@v5
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './src'
-
+          # Upload entire repository
+          path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,4 +1,3 @@
-# Deploy static content to GitHub Pages
 name: Deploy static content to Pages
 
 on:
@@ -31,10 +30,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload both folders
-          path: |
-            src
-            res
+          path: './src'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,28 +1,21 @@
-# Simple workflow for deploying static content to GitHub Pages
+# Deploy static content to GitHub Pages
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -31,13 +24,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload both folders
+          path: |
+            src
+            res
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/src/index.html
+++ b/src/index.html
@@ -30,40 +30,42 @@
 </header>
 
 <div class="container">
-  <section id="instructions" class="card">
+  <section id="instructions-section" class="card">
     <h2>Smithing Instructions</h2>
-    <div class="instruction-set instruction-set-1">
-      <img src="../res/empty.png" class="action-icon" alt="None" data-action="">
-      <select class="priority">
-        <option value="">None</option>
-        <option value="last">Last</option>
-        <option value="second-last">Second Last</option>
-        <option value="third-last">Third Last</option>
-        <option value="not-last">Not Last</option>
-        <option value="any">Any</option>
-      </select>
-    </div>
-    <div class="instruction-set instruction-set-2">
-      <img src="../res/empty.png" class="action-icon" alt="None" data-action="">
-      <select class="priority">
-        <option value="">None</option>
-        <option value="last">Last</option>
-        <option value="second-last">Second Last</option>
-        <option value="third-last">Third Last</option>
-        <option value="not-last">Not Last</option>
-        <option value="any">Any</option>
-      </select>
-    </div>
-    <div class="instruction-set instruction-set-3">
-      <img src="../res/empty.png" class="action-icon" alt="None" data-action="">
-      <select class="priority">
-        <option value="">None</option>
-        <option value="last">Last</option>
-        <option value="second-last">Second Last</option>
-        <option value="third-last">Third Last</option>
-        <option value="not-last">Not Last</option>
-        <option value="any">Any</option>
-      </select>
+    <div id="instructions">
+      <div class="instruction-set instruction-set-1">
+        <img src="../res/empty.png" class="action-icon" alt="None" data-action="">
+        <select class="priority">
+          <option value="">None</option>
+          <option value="last">Last</option>
+          <option value="second-last">Second Last</option>
+          <option value="third-last">Third Last</option>
+          <option value="not-last">Not Last</option>
+          <option value="any">Any</option>
+        </select>
+      </div>
+      <div class="instruction-set instruction-set-2">
+        <img src="../res/empty.png" class="action-icon" alt="None" data-action="">
+        <select class="priority">
+          <option value="">None</option>
+          <option value="last">Last</option>
+          <option value="second-last">Second Last</option>
+          <option value="third-last">Third Last</option>
+          <option value="not-last">Not Last</option>
+          <option value="any">Any</option>
+        </select>
+      </div>
+      <div class="instruction-set instruction-set-3">
+        <img src="../res/empty.png" class="action-icon" alt="None" data-action="">
+        <select class="priority">
+          <option value="">None</option>
+          <option value="last">Last</option>
+          <option value="second-last">Second Last</option>
+          <option value="third-last">Third Last</option>
+          <option value="not-last">Not Last</option>
+          <option value="any">Any</option>
+        </select>
+      </div>
     </div>
   </section>
 

--- a/src/script.js
+++ b/src/script.js
@@ -158,9 +158,11 @@ document.getElementById("calculate-button").addEventListener("click", function()
 
 
   function calculateSetupActions(targetValue, instructions) {
+    // First, apply the instructions that already have actions
     let instructionSum = 0;
     instructions.forEach(instr => {
       if (instr.action === "hit") {
+        // Pick best hit for the current remaining target
         const bestHit = selectBestHit(targetValue - instructionSum, ["hit1", "hit2", "hit3"]);
         instructionSum += actions[bestHit];
         instr.action = bestHit;
@@ -172,29 +174,32 @@ document.getElementById("calculate-button").addEventListener("click", function()
     let preTargetValue = targetValue - instructionSum;
     if (preTargetValue === 0) return [];
   
-    const queue = [[0, []]]; // [currentValue, actionsPath]
-    const visited = new Set([0]);
-    
+    // BFS with shortest-path tracking
+    const queue = [[0, []]]; // [currentValue, path]
+    const visited = new Map(); // value => shortest path length
+    visited.set(0, 0);
+  
     while (queue.length > 0) {
       const [currentValue, path] = queue.shift();
-    
+  
       if (currentValue === preTargetValue) return path;
-    
-      // Sort actions by how close they get to the target
+  
+      // Sort actions so that we try moves that get closer to the target first
       const sortedActions = Object.entries(actions)
         .sort(([, value]) => Math.abs(preTargetValue - (currentValue + value)));
-    
+  
       for (let [action, value] of sortedActions) {
         const nextValue = currentValue + value;
-    
-        if (!visited.has(nextValue)) {
-          visited.add(nextValue);
+  
+        // Only proceed if we haven't reached this value with fewer or equal steps
+        if (!visited.has(nextValue) || visited.get(nextValue) > path.length + 1) {
+          visited.set(nextValue, path.length + 1);
           queue.push([nextValue, [...path, action]]);
         }
       }
     }
   
-    // If BFS fails (should never happen), return empty array instead of null
+    // This should never happen
     return [];
   }
 

--- a/src/script.js
+++ b/src/script.js
@@ -125,6 +125,34 @@ document.getElementById("calculate-button").addEventListener("click", function()
     return bestHitAction;
   }
 
+  function displayGroupedActions(container, actions) {
+    // Group identical actions
+    const grouped = actions.reduce((acc, action) => {
+      const key = typeof action === "string" ? action : action.action;
+      acc[key] = (acc[key] || 0) + 1;
+      return acc;
+    }, {});
+  
+    // Render grouped actions
+    Object.entries(grouped).forEach(([action, count]) => {
+      const wrapper = document.createElement("div");
+      wrapper.classList.add("action-with-count");
+  
+      const img = createActionImage(action);
+      wrapper.appendChild(img);
+  
+      if (count > 1) {
+        const countText = document.createElement("div");
+        countText.classList.add("action-count");
+        countText.textContent = `×${count}`;
+        wrapper.appendChild(countText);
+      }
+  
+      container.appendChild(wrapper);
+    });
+  }
+
+
   function calculateSetupActions(targetValue, instructions) {
     let instructionSum = 0;
     instructions.forEach(instr => {
@@ -210,33 +238,10 @@ document.getElementById("calculate-button").addEventListener("click", function()
   finalContainer.innerHTML = "";
 
   // Group and append setup actions
-  const groupedSetup = {};
-  setupActions.forEach(action => {
-    groupedSetup[action] = (groupedSetup[action] || 0) + 1;
-  });
-  
-  Object.entries(groupedSetup).forEach(([action, count]) => {
-    const wrapper = document.createElement("div");
-    wrapper.classList.add("action-with-count");
-  
-    const img = createActionImage(action);
-    wrapper.appendChild(img);
-  
-    if (count > 1) {
-      const countText = document.createElement("div");
-      countText.classList.add("action-count");
-      countText.textContent = `×${count}`;
-      wrapper.appendChild(countText);
-    }
-  
-    setupContainer.appendChild(wrapper);
-  });
+  displayGroupedActions(setupContainer, setupActions);
 
-
-  // Append final instructions as images
-  sortedInstructions.forEach(instr => {
-    finalContainer.appendChild(createActionImage(instr.action));
-  });
+  // Group and append final instructions
+  displayGroupedActions(finalContainer, sortedInstructions);
 
   // Show the result card with a transition
   const resultCard = document.getElementById("result");

--- a/src/script.js
+++ b/src/script.js
@@ -307,13 +307,13 @@ function setupInstructionListener(selector) {
   applyTooltipToIcon(icon);
 }
 
-// Function to reset all inputs and selections
 function resetPage() {
   // Reset target value input
   document.getElementById('target-value').value = '';
 
   // Reset instruction sets
-  document.querySelectorAll('.instruction-set').forEach(set => {
+  const defaults = ['last', 'second-last', 'third-last'];
+  document.querySelectorAll('.instruction-set').forEach((set, index) => {
     const actionIcon = set.querySelector('.action-icon');
     actionIcon.src = '../res/empty.png';
     actionIcon.setAttribute('data-action', '');
@@ -321,7 +321,7 @@ function resetPage() {
 
     const prioritySelect = set.querySelector('.priority');
     if (prioritySelect) {
-      prioritySelect.selectedIndex = 0;
+      prioritySelect.value = defaults[index] || '';
     }
   });
 

--- a/src/script.js
+++ b/src/script.js
@@ -10,8 +10,12 @@ document.addEventListener('DOMContentLoaded', function() {
     icon.setAttribute('data-action', '');
   });
 
-  document.querySelectorAll('.priority').forEach(select => {
-    select.selectedIndex = 0;
+  const defaults = ['last', 'second-last', 'third-last'];
+  document.querySelectorAll('.instruction-set').forEach((set, index) => {
+    const select = set.querySelector('.priority');
+    if (select) {
+      select.value = defaults[index] || '';
+    }
   });
 
   document.getElementById('target-value').value = '';

--- a/src/script.js
+++ b/src/script.js
@@ -286,10 +286,9 @@ document.getElementById("calculate-button").addEventListener("click", function()
     const notLast = instructions.filter(i => i.priority === "not-last");
     const anyPriority = instructions.filter(i => i.priority === "any");
   
-    // Build base sequence (flexible instructions first)
+    // Build sequence: flexible first, then finals in strict order
     let combined = [...anyPriority, ...notLast];
   
-    // Now add fixed slots in strict order
     const finals = [];
     if (thirdLast) finals.push(thirdLast);
     if (secondLast) finals.push(secondLast);
@@ -297,46 +296,33 @@ document.getElementById("calculate-button").addEventListener("click", function()
   
     combined = [...combined, ...finals];
   
-    // --- Validation ---
+    // --- Validation (with conditional debug logging) ---
     const len = combined.length;
     if (len === 0) throw new Error("Empty instruction sequence!");
   
+    function logAndThrow(msg) {
+      console.group("sortInstructions Constraint Violation");
+      console.log("Error:", msg);
+      console.log("Input instructions:", instructions.map(i => `${i.action} (${i.priority})`));
+      console.log("Combined result:", combined.map(i => `${i.action} (${i.priority})`));
+      console.groupEnd();
+      throw new Error(msg);
+    }
+  
     if (last && combined[len - 1] !== last)
-      throw new Error("Constraint violation: 'last' not in last position");
+      logAndThrow("'last' not in last position");
   
-    if (secondLast && combined[len - 2] !== secondLast)
-      throw new Error("Constraint violation: 'second-last' not in second-last position");
+    if (secondLast && len >= 2 && combined[len - 2] !== secondLast)
+      logAndThrow("'second-last' not in second-last position");
   
-    if (thirdLast && combined[len - 3] !== thirdLast)
-      throw new Error("Constraint violation: 'third-last' not in third-last position");
+    if (thirdLast && len >= 3 && combined[len - 3] !== thirdLast)
+      logAndThrow("'third-last' not in third-last position");
   
     if (combined[len - 1]?.priority === "not-last")
-      throw new Error("Constraint violation: 'not-last' placed last");
+      logAndThrow("'not-last' placed last");
   
     return combined;
   }
-
-  const setupActions = calculateSetupActions(targetValue, instructions);
-  const sortedInstructions = sortInstructions(instructions);
-
-  // Display results as images
-  const setupContainer = document.getElementById("setup-actions");
-  const finalContainer = document.getElementById("final-actions");
-
-  // Clear previous results
-  setupContainer.innerHTML = "";
-  finalContainer.innerHTML = "";
-
-  // Group and append setup actions
-  displayGroupedActions(setupContainer, setupActions);
-
-  // Group and append final instructions
-  displayGroupedActions(finalContainer, sortedInstructions);
-
-  // Show the result card with a transition
-  const resultCard = document.getElementById("result");
-  resultCard.classList.add("visible");
-});
 
 // Single function to manage icon selection
 function setupInstructionListener(selector) {

--- a/src/script.js
+++ b/src/script.js
@@ -168,30 +168,41 @@ document.getElementById("calculate-button").addEventListener("click", function()
         instructionSum += actions[instr.action];
       }
     });
-
+  
     let preTargetValue = targetValue - instructionSum;
-
-    const setupActions = [];
-    let currentValue = preTargetValue;
-
-    // Determine which action to use to reach the target (can be negative or positive)
-    while (currentValue !== 0) {
-      let bestAction = null;
-      let minDiff = Infinity;
-
+    
+    // Handle zero case
+    if (preTargetValue === 0) {
+      return [];
+    }
+    
+    // Use BFS to find optimal path for both positive and negative values
+    const queue = [[0, []]]; // [currentValue, actionsPath]
+    const visited = new Set([0]);
+    
+    while (queue.length > 0) {
+      const [currentValue, path] = queue.shift();
+      
+      // Check if we've reached the target
+      if (currentValue === preTargetValue) {
+        return path;
+      }
+      
+      // Try all possible actions
       for (let action in actions) {
-        let nextValue = currentValue - actions[action];
-        if (Math.abs(nextValue) < minDiff) {
-          minDiff = Math.abs(nextValue);
-          bestAction = action;
+        const nextValue = currentValue + actions[action];
+        
+        // Bound the search space to prevent infinite loops
+        const maxSearch = Math.max(Math.abs(preTargetValue) * 2, 100);
+        if (!visited.has(nextValue) && Math.abs(nextValue) <= maxSearch) {
+          visited.add(nextValue);
+          queue.push([nextValue, [...path, action]]);
         }
       }
-
-      setupActions.push(bestAction);
-      currentValue -= actions[bestAction];
     }
-
-    return setupActions;
+    
+    // Fallback: should not reach here if solution exists
+    return [];
   }
 
   function sortInstructions(instructions) {

--- a/src/script.js
+++ b/src/script.js
@@ -323,7 +323,29 @@ document.getElementById("calculate-button").addEventListener("click", function()
   
     return combined;
   }
+
+  const setupActions = calculateSetupActions(targetValue, instructions);
+  const sortedInstructions = sortInstructions(instructions);
+
+  // Display results as images
+  const setupContainer = document.getElementById("setup-actions");
+  const finalContainer = document.getElementById("final-actions");
+
+  // Clear previous results
+  setupContainer.innerHTML = "";
+  finalContainer.innerHTML = "";
+
+  // Group and append setup actions
+  displayGroupedActions(setupContainer, setupActions);
+
+  // Group and append final instructions
+  displayGroupedActions(finalContainer, sortedInstructions);
+
+  // Show the result card with a transition
+  const resultCard = document.getElementById("result");
+  resultCard.classList.add("visible");
 });
+
 // Single function to manage icon selection
 function setupInstructionListener(selector) {
   const icon = document.querySelector(selector + ' .action-icon');

--- a/src/script.js
+++ b/src/script.js
@@ -186,7 +186,7 @@ document.getElementById("calculate-button").addEventListener("click", function()
       if (currentValue === preTargetValue) return path;
       if (path.length >= MAX_BFS_STEPS) continue;
   
-      // Try moves that get closer first
+      // Try all actions, moving closer to target
       const sortedActions = Object.entries(actions)
         .sort(([, value]) => Math.abs(preTargetValue - (currentValue + value)));
   
@@ -226,31 +226,29 @@ document.getElementById("calculate-button").addEventListener("click", function()
   
     return greedyPath;
   }
-
+  
   function sortInstructions(instructions) {
     const last = instructions.filter(i => i.priority === 'last');
     const secondLast = instructions.filter(i => i.priority === 'second-last');
     const thirdLast = instructions.filter(i => i.priority === 'third-last');
     const notLast = instructions.filter(i => i.priority === 'not-last');
     const anyPriority = instructions.filter(i => i.priority === 'any');
-
-    let sortedInstructions = [...thirdLast, ...secondLast, ...notLast, ...last];
-
+  
+    // Start with fixed positions at the end
+    let sortedInstructions = [...thirdLast, ...secondLast, ...last];
+  
+    // Insert 'any' instructions somewhere before the very last instruction
     if (anyPriority.length > 0) {
-      const anyHits = anyPriority.map(i => i);
-
-      let insertionPoint = 0;
-      if (last.length > 0 && secondLast.length > 0) {
-        insertionPoint = sortedInstructions.length - last.length - secondLast.length;
-      } else if (last.length > 0) {
-        insertionPoint = sortedInstructions.length - last.length;
-      } else {
-        insertionPoint = sortedInstructions.length;
-      }
-
-      sortedInstructions.splice(insertionPoint, 0, ...anyHits);
+      const insertionPoint = sortedInstructions.length > 0 ? sortedInstructions.length - 1 : 0;
+      sortedInstructions.splice(insertionPoint, 0, ...anyPriority);
     }
-
+  
+    // Insert 'not-last' instructions anywhere except last
+    if (notLast.length > 0) {
+      const safeInsertionPoint = sortedInstructions.length > 0 ? sortedInstructions.length - 1 : 0;
+      sortedInstructions.splice(safeInsertionPoint, 0, ...notLast);
+    }
+  
     return sortedInstructions;
   }
 

--- a/src/script.js
+++ b/src/script.js
@@ -170,43 +170,39 @@ document.getElementById("calculate-button").addEventListener("click", function()
     });
   
     let preTargetValue = targetValue - instructionSum;
-    
-    // Handle zero case
-    if (preTargetValue === 0) {
-      return [];
-    }
-    
-    // Use BFS to find optimal path for both positive and negative values
-    const queue = [[0, []]]; // [currentValue, actionsPath]
+    if (preTargetValue === 0) return [];
+  
+    const queue = [[0, []]];
     const visited = new Set([0]);
-    
-    while (queue.length > 0) {
+    const maxSearch = Math.max(Math.abs(preTargetValue) * 3, 100);
+    const maxIterations = 50000;
+    let iterations = 0;
+  
+    while (queue.length > 0 && iterations < maxIterations) {
+      iterations++;
       const [currentValue, path] = queue.shift();
-      
-      // Check if we've reached the target
+  
       if (currentValue === preTargetValue) {
         return path;
       }
-      
-      // Try all possible actions
+  
       for (let action in actions) {
         const nextValue = currentValue + actions[action];
-        
-        // Bound the search space to prevent infinite loops
-        const maxSearch = Math.max(Math.abs(preTargetValue) * 2, 100);
+  
+        // Allow exploration slightly beyond target (overshoot)
         if (
           !visited.has(nextValue) &&
-          Math.abs(nextValue - preTargetValue) <= maxSearch && // stay near the target
-          Math.abs(nextValue) <= maxSearch                     // stay near zero
+          Math.abs(nextValue) <= maxSearch &&
+          Math.abs(nextValue - preTargetValue) <= maxSearch
         ) {
           visited.add(nextValue);
           queue.push([nextValue, [...path, action]]);
         }
       }
     }
-    
-    // Fallback: should not reach here if solution exists
-    return [];
+  
+    // If no valid path found, return null to handle gracefully
+    return null;
   }
 
   function sortInstructions(instructions) {

--- a/src/script.js
+++ b/src/script.js
@@ -209,10 +209,29 @@ document.getElementById("calculate-button").addEventListener("click", function()
   setupContainer.innerHTML = "";
   finalContainer.innerHTML = "";
 
-  // Append setup actions as images
+  // Group and append setup actions
+  const groupedSetup = {};
   setupActions.forEach(action => {
-    setupContainer.appendChild(createActionImage(action));
+    groupedSetup[action] = (groupedSetup[action] || 0) + 1;
   });
+  
+  Object.entries(groupedSetup).forEach(([action, count]) => {
+    const wrapper = document.createElement("div");
+    wrapper.classList.add("action-with-count");
+  
+    const img = createActionImage(action);
+    wrapper.appendChild(img);
+  
+    if (count > 1) {
+      const countText = document.createElement("div");
+      countText.classList.add("action-count");
+      countText.textContent = `×${count}`;
+      wrapper.appendChild(countText);
+    }
+  
+    setupContainer.appendChild(wrapper);
+  });
+
 
   // Append final instructions as images
   sortedInstructions.forEach(instr => {

--- a/src/script.js
+++ b/src/script.js
@@ -130,30 +130,30 @@ document.getElementById("calculate-button").addEventListener("click", function()
   }
 
   function displayGroupedActions(container, actions) {
-    // Group identical actions
-    const grouped = actions.reduce((acc, action) => {
-      const key = typeof action === "string" ? action : action.action;
-      acc[key] = (acc[key] || 0) + 1;
-      return acc;
-    }, {});
-  
-    // Render grouped actions
-    Object.entries(grouped).forEach(([action, count]) => {
+    let i = 0;
+    while (i < actions.length) {
+      const current = typeof actions[i] === "string" ? actions[i] : actions[i].action;
+      let count = 1;
+      while (i + count < actions.length &&
+             (typeof actions[i + count] === "string" ? actions[i + count] : actions[i + count].action) === current) {
+        count++;
+      }
+
       const wrapper = document.createElement("div");
       wrapper.classList.add("action-with-count");
-  
-      const img = createActionImage(action);
+      const img = createActionImage(current);
       wrapper.appendChild(img);
-  
+
       if (count > 1) {
         const countText = document.createElement("div");
         countText.classList.add("action-count");
         countText.textContent = `×${count}`;
         wrapper.appendChild(countText);
       }
-  
+
       container.appendChild(wrapper);
-    });
+      i += count;
+    }
   }
 
 
@@ -170,35 +170,26 @@ document.getElementById("calculate-button").addEventListener("click", function()
     });
 
     let preTargetValue = targetValue - instructionSum;
-    const dp = Array(preTargetValue + 1).fill(Infinity);
-    dp[0] = 0;
 
-    for (let i = 0; i <= preTargetValue; i++) {
-      if (dp[i] !== Infinity) {
-        for (let action in actions) {
-          let nextValue = i + actions[action];
-          if (nextValue <= preTargetValue) {
-            dp[nextValue] = Math.min(dp[nextValue], dp[i] + 1);
-          }
-        }
-      }
-    }
-
-    let setupActions = [];
+    const setupActions = [];
     let currentValue = preTargetValue;
 
-    while (currentValue > 0) {
+    // Determine which action to use to reach the target (can be negative or positive)
+    while (currentValue !== 0) {
+      let bestAction = null;
+      let minDiff = Infinity;
+
       for (let action in actions) {
-        let prevValue = currentValue - actions[action];
-        if (prevValue >= 0 && dp[prevValue] === dp[currentValue] - 1) {
-          setupActions.push(action);
-          currentValue = prevValue;
-          break;
+        let nextValue = currentValue - actions[action];
+        if (Math.abs(nextValue) < minDiff) {
+          minDiff = Math.abs(nextValue);
+          bestAction = action;
         }
       }
-    }
 
-    setupActions.reverse();
+      setupActions.push(bestAction);
+      currentValue -= actions[bestAction];
+    }
 
     return setupActions;
   }
@@ -348,6 +339,5 @@ window.addEventListener('load', resetPage);
 setupInstructionListener('.instruction-set-1');
 setupInstructionListener('.instruction-set-2');
 setupInstructionListener('.instruction-set-3');
-
 
 

--- a/src/script.js
+++ b/src/script.js
@@ -172,37 +172,26 @@ document.getElementById("calculate-button").addEventListener("click", function()
     let preTargetValue = targetValue - instructionSum;
     if (preTargetValue === 0) return [];
   
-    const queue = [[0, []]];
+    const queue = [[0, []]]; // [currentValue, actionsPath]
     const visited = new Set([0]);
-    const maxSearch = Math.max(Math.abs(preTargetValue) * 3, 100);
-    const maxIterations = 50000;
-    let iterations = 0;
   
-    while (queue.length > 0 && iterations < maxIterations) {
-      iterations++;
+    while (queue.length > 0) {
       const [currentValue, path] = queue.shift();
   
-      if (currentValue === preTargetValue) {
-        return path;
-      }
+      if (currentValue === preTargetValue) return path;
   
       for (let action in actions) {
         const nextValue = currentValue + actions[action];
   
-        // Allow exploration slightly beyond target (overshoot)
-        if (
-          !visited.has(nextValue) &&
-          Math.abs(nextValue) <= maxSearch &&
-          Math.abs(nextValue - preTargetValue) <= maxSearch
-        ) {
+        if (!visited.has(nextValue)) {
           visited.add(nextValue);
           queue.push([nextValue, [...path, action]]);
         }
       }
     }
   
-    // If no valid path found, return null to handle gracefully
-    return null;
+    // If BFS fails (should never happen), return empty array instead of null
+    return [];
   }
 
   function sortInstructions(instructions) {

--- a/src/script.js
+++ b/src/script.js
@@ -323,7 +323,7 @@ document.getElementById("calculate-button").addEventListener("click", function()
   
     return combined;
   }
-
+});
 // Single function to manage icon selection
 function setupInstructionListener(selector) {
   const icon = document.querySelector(selector + ' .action-icon');
@@ -420,4 +420,3 @@ window.addEventListener('load', resetPage);
 setupInstructionListener('.instruction-set-1');
 setupInstructionListener('.instruction-set-2');
 setupInstructionListener('.instruction-set-3');
-

--- a/src/script.js
+++ b/src/script.js
@@ -174,15 +174,19 @@ document.getElementById("calculate-button").addEventListener("click", function()
   
     const queue = [[0, []]]; // [currentValue, actionsPath]
     const visited = new Set([0]);
-  
+    
     while (queue.length > 0) {
       const [currentValue, path] = queue.shift();
-  
+    
       if (currentValue === preTargetValue) return path;
-  
-      for (let action in actions) {
-        const nextValue = currentValue + actions[action];
-  
+    
+      // Sort actions by how close they get to the target
+      const sortedActions = Object.entries(actions)
+        .sort(([, value]) => Math.abs(preTargetValue - (currentValue + value)));
+    
+      for (let [action, value] of sortedActions) {
+        const nextValue = currentValue + value;
+    
         if (!visited.has(nextValue)) {
           visited.add(nextValue);
           queue.push([nextValue, [...path, action]]);

--- a/src/script.js
+++ b/src/script.js
@@ -325,13 +325,13 @@ document.getElementById("calculate-button").addEventListener("click", function()
     function validate(seq) {
       const len = seq.length;
       if (len === 0) throw new Error("Empty instruction sequence!");
-  
+    
       seq.forEach((instr, idx) => {
         if (instr.priority === "last" && idx !== len - 1)
           throw new Error("Constraint violation: 'last' not in last position");
-        if (instr.priority === "second-last" && idx !== len - 2)
+        if (instr.priority === "second-last" && len >= 2 && idx !== len - 2)
           throw new Error("Constraint violation: 'second-last' not in second-last position");
-        if (instr.priority === "third-last" && idx !== len - 3)
+        if (instr.priority === "third-last" && len >= 3 && idx !== len - 3)
           throw new Error("Constraint violation: 'third-last' not in third-last position");
         if (instr.priority === "not-last" && idx === len - 1)
           throw new Error("Constraint violation: 'not-last' placed last");

--- a/src/styles.css
+++ b/src/styles.css
@@ -217,6 +217,22 @@ button:hover {
   color: inherit;
 }
 
+/* Horizontal layout for instruction sets */
+#instructions {
+  display: flex;
+  flex-direction: row;      /* horizontal layout */
+  gap: 20px;                /* spacing between instruction sets */
+  align-items: flex-start;  /* align icons and dropdowns */
+  flex-wrap: wrap;          /* wrap to next line if screen too small */
+}
+
+.instruction-set {
+  display: flex;
+  flex-direction: column;   /* icon above dropdown */
+  align-items: center;
+  margin-bottom: 20px;
+}
+
 /* Adjusting image size within the instruction section */
 .instruction-set .action-icon {
   width: 64px;
@@ -235,16 +251,6 @@ select {
   font-size: 14px;
   border-radius: 4px;
   border: 1px solid inherit;
-}
-
-.instruction-set {
-  margin-bottom: 20px;
-  display: flex;
-  align-items: center;
-}
-
-.instruction-set img {
-  margin-right: 10px;
 }
 
 .action-icon {
@@ -388,6 +394,11 @@ input:checked + .slider:before {
     position: static;
     transform: none;
     margin: 10px 0;
+  }
+
+  #instructions {
+    flex-direction: column;  /* stack vertically on mobile */
+    align-items: center;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -220,24 +220,25 @@ button:hover {
 /* Horizontal layout for instruction sets */
 #instructions {
   display: flex;
-  flex-direction: row;      /* horizontal layout */
-  gap: 20px;                /* spacing between instruction sets */
-  align-items: flex-start;  /* align icons and dropdowns */
-  flex-wrap: wrap;          /* wrap to next line if screen too small */
+  flex-direction: row;
+  justify-content: center;
+  gap: 20px;
+  align-items: flex-start;
+  flex-wrap: wrap;
 }
 
 .instruction-set {
   display: flex;
-  flex-direction: column;   /* icon above dropdown */
+  flex-direction: column;
   align-items: center;
   margin-bottom: 20px;
 }
 
-/* Optional: spacing between the section title and instructions */
+/* Spacing between the section title and instructions */
 #instructions-section h2 {
   width: 100%;
   margin-bottom: 10px;
-  text-align: left;   /* or center if preferred */
+  text-align: left;
 }
 
 /* Adjusting image size within the instruction section */

--- a/src/styles.css
+++ b/src/styles.css
@@ -390,3 +390,16 @@ input:checked + .slider:before {
     margin: 10px 0;
   }
 }
+
+.action-with-count {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 5px;
+}
+
+.action-count {
+  font-size: 0.9em;
+  color: #aaa;
+  margin-top: 2px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -233,6 +233,13 @@ button:hover {
   margin-bottom: 20px;
 }
 
+/* Optional: spacing between the section title and instructions */
+#instructions-section h2 {
+  width: 100%;
+  margin-bottom: 10px;
+  text-align: left;   /* or center if preferred */
+}
+
 /* Adjusting image size within the instruction section */
 .instruction-set .action-icon {
   width: 64px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -234,6 +234,11 @@ button:hover {
   margin-bottom: 20px;
 }
 
+.instruction-set select {
+  text-align: center;
+  text-align-last: center;
+}
+
 /* Spacing between the section title and instructions */
 #instructions-section h2 {
   width: 100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -392,14 +392,18 @@ input:checked + .slider:before {
 }
 
 .action-with-count {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
+  position: relative; /* new */
+  display: inline-block; /* shrink-wrap to image size */
   margin: 5px;
 }
 
 .action-count {
+  position: absolute; /* new */
+  bottom: 2px;   /* adjust as needed */
+  right: 2px;    /* adjust as needed */
   font-size: 0.9em;
-  color: #aaa;
-  margin-top: 2px;
+  color: #fff;
+  background: rgba(0,0,0,0.5); /* optional: makes the text readable */
+  padding: 1px 4px;
+  border-radius: 2px;
 }


### PR DESCRIPTION
Replaced the multiple repeated action icons under each instruction with a single x6 (for example) icon for clarity.  

Additionally, the smithing instructions section text has been centered for readability, and I also set the defaults for the dropdowns to last, second last, and third last (as this is usually what it seems to be by default for me while smithing). But this is optional and can be reverted if not preferred.

Finally, I have made it so that negative target values are accepted input. (Sometimes I make mistakes while smithing and have to fix...)